### PR TITLE
Add condition for fully-qualified global functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,6 +112,16 @@ module.exports = ( pattern = '**/*.php', config = {} ) => {
 
 				parensBalance = 0;
 
+			//Look for T_NAME_FULLY_QUALIFIED functions
+			} else if ( token.includes( 'T_NAME_FULLY_QUALIFIED' ) && functions.indexOf( text.slice(1) ) > -1 ){
+				gettext = {
+					name: text.slice(1),
+					line: line,
+					domain: false,
+					argument: 0,
+				};
+				parensBalance = 0;
+
 			//Check for T_CONSTANT_ENCAPSED_STRING - and that we are in the text-domain argument
 			} else if ( token.includes( 'T_CONSTANT_ENCAPSED_STRING' ) && gettext.line && funcDomain[ gettext.name ] === gettext.argument ) {
 


### PR DESCRIPTION
The current implementation doesn't cover the case of a WordPress i18n global function written with a leading backslash (e.g. `\__()`) because the PHP parser does not identify `\__()` as a `T_STRING` but rather as a `T_NAME_FULLY_QUALIFIED`.

The proposed change takes that case into account by adding a new condition that is satisfied when the current `token` is `T_NAME_FULLY_QUALIFIED` and its text, starting from the second character (i.e. `text.slice(1)`), is one of the i18n functions.

This case is necessary when a WordPress component uses external libraries that are automatically namespaced by a processor such as PHP Scoper, which transforms the name of every global function into a fully-qualified name (e.g. `esc_html__()` becomes `\esc_html__()`).